### PR TITLE
Fix typo in read_ods docstring

### DIFF
--- a/pandas_ods_reader/main.py
+++ b/pandas_ods_reader/main.py
@@ -21,7 +21,7 @@ def read_ods(file_or_path, sheet=1, headers=True, columns=None):
     sheet : int or str, default 1
         If `int`, the 1 based index of the sheet to be read. If `str`, the
         name of the sheet to be read.
-    header : bool, default True
+    headers : bool, default True
         If `True`, then the first row is treated as the list of column names.
     columns : list, default None, optional
         A list of column names to be used as headers.


### PR DESCRIPTION
The actual function argument is named 'headers', but the docstring says 'header'.  Sorry for the nit, but that just tripped me for a second. :')